### PR TITLE
Protect against unintentionally wrongly set env var XRAY_VIVADO

### DIFF
--- a/utils/environment.sh
+++ b/utils/environment.sh
@@ -49,7 +49,7 @@ export XRAY_VIVADO="${XRAY_UTILS_DIR}/vivado.sh"
 # Verify an approved version is in use
 export XRAY_VIVADO_SETTINGS="${XRAY_VIVADO_SETTINGS:-/opt/Xilinx/Vivado/2017.2/settings64.sh}"
 # Vivado v2017.2 (64-bit)
-if [ $(${XRAY_VIVADO} -h |grep Vivado |cut -d\  -f 2) != "v2017.2" ] ; then
+if [ "$(${XRAY_VIVADO} -h |grep Vivado |cut -d\  -f 2)" != "v2017.2" ] ; then
     echo "Requires Vivado 2017.2. See https://github.com/SymbiFlow/prjxray/issues/14"
     # Can't exit since sourced script
     # Trash a key environment variable to preclude use


### PR DESCRIPTION
For everyday use, it is common to use a personal wrapper setenv script that both sets Vivado license environment, and that sources the usual vivado settings64.sh.

If by mistake such wrapper is set in XRAY_VIVADO env var instead of the required settings.sh, then weird things can happen to the prompt when utils/environment.sh is sourced.

This PR is really simple : just protect source of $XRAY_VIVADO with quotes.