### PR TITLE
Fix race condition

### DIFF
--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-name: CI Build
+name: Database
 
 jobs:
   BuildDatabase:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-name: CI Build
+name: Tests
 
 jobs:
 

--- a/utils/dbfixup.py
+++ b/utils/dbfixup.py
@@ -536,8 +536,10 @@ def update_seg_fns(
         changes += new_changes
 
         with open(fn_out, "w") as f:
+            util.lock_file(f, 10)
             for line in sorted(lines):
                 print(line, file=f)
+            util.unlock_file(f)
 
         if changes is not None:
             seg_files += 1

--- a/utils/sort_db.py
+++ b/utils/sort_db.py
@@ -65,6 +65,7 @@ import sys
 import json
 import utils.xjson as xjson
 import utils.cmp as cmp
+from prjxray.util import lock_file, unlock_file
 
 
 def split_all(s, chars):
@@ -344,9 +345,11 @@ def sort_db(pathname):
     #            copy[i], tosort[i])
 
     with open(pathname, 'w') as f:
+        lock_file(f, 10)
         for _, l in tosort:
             f.write(l)
             f.write('\n')
+        unlock_file(f)
 
     return True
 
@@ -405,8 +408,10 @@ def sort_db_text(n):
     rows.sort(key=lambda i: i[0])
 
     with open(n, 'w') as f:
+        lock_file(f, 10)
         for l in rows:
             f.write(l[-1])
+        unlock_file(f)
 
     return True
 


### PR DESCRIPTION
There seem to be yet another race condition that causes an [intermittent failure](https://github.com/f4pga/prjxray/runs/5489565933?check_suite_focus=true):

```
- 2h40m: Traceback (most recent call last):
- 2h40m:   File "/root/prjxray/prjxray/utils/bit2fasm.py", line 126, in <module>
- 2h40m:     main()
- 2h40m:   File "/root/prjxray/prjxray/utils/bit2fasm.py", line 122, in main
- 2h40m:     args.canonical)
- 2h40m:   File "/root/prjxray/prjxray/utils/bit2fasm.py", line 50, in bits_to_fasm
- 2h40m:     sort_key=grid.tile_key,
- 2h40m:   File "/root/prjxray/prjxray/third_party/fasm/fasm/output.py", line 386, in merge_and_sort
- 2h40m:     for line in model:
- 2h40m:   File "/root/prjxray/prjxray/prjxray/fasm_disassembler.py", line 131, in find_features_in_bitstream
- 2h40m:     solved_bitdata, bitdata, verbose=verbose):
- 2h40m:   File "/root/prjxray/prjxray/prjxray/fasm_disassembler.py", line 61, in find_features_in_tile
- 2h40m:     tile_segbits = self.grid.get_tile_segbits_at_tilename(tile_name)
- 2h40m:   File "/root/prjxray/prjxray/prjxray/grid.py", line 149, in get_tile_segbits_at_tilename
- 2h40m:     return self.db.get_tile_segbits(gridinfo.tile_type)
- 2h40m:   File "/root/prjxray/prjxray/prjxray/db.py", line 218, in get_tile_segbits
- 2h40m:     self.tile_types[tile_type.upper()])
- 2h40m:   File "/root/prjxray/prjxray/prjxray/tile_segbits.py", line 95, in __init__
- 2h40m:     self.segbits[BlockType.CLB_IO_CLK] = read_segbits(f)
- 2h40m:   File "/root/prjxray/prjxray/prjxray/tile_segbits.py", line 75, in read_segbits
- 2h40m:     segbits[parts[0]] = [parsebit(val) for val in parts[1:]]
- 2h40m:   File "/root/prjxray/prjxray/prjxray/tile_segbits.py", line 75, in <listcomp>
- 2h40m:     segbits[parts[0]] = [parsebit(val) for val in parts[1:]]
- 2h40m:   File "/root/prjxray/prjxray/prjxray/tile_segbits.py", line 56, in parsebit
- 2h40m:     word_bit=int(word_bit_n),
- 2h40m: ValueError: invalid literal for int() with base 10: '1END2'

```

The above error is most probably a result of a `.db` file corruption from another process while it is being read to access its information. 