### PR TITLE
Fix regressions introduced by the changes to make CI green

### DIFF
--- a/fuzzers/036-iob18-ologic/generate.py
+++ b/fuzzers/036-iob18-ologic/generate.py
@@ -18,7 +18,7 @@ DEBUG_FUZZER = False
 
 
 def bitfilter(frame, word):
-    return 30 <= frame and frame <= 33
+    return (30 <= frame and frame <= 33) or frame == 38 or frame == 39
 
 def handle_data_width(segmk, d):
     if 'DATA_WIDTH' not in d:


### PR DESCRIPTION
The differential output and the button->led path stopped working due to changes introduced to get CI green.
