### PR TITLE
readme: update shield syntax (badges/shields#8671)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Documentation Status](https://img.shields.io/readthedocs/prjxray?longCache=true&style=flat-square&logo=ReadTheDocs&logoColor=fff)](http://prjxray.readthedocs.org/)
 [![License](https://img.shields.io/github/license/f4pga/prjxray.svg?longCache=true&style=flat-square&label=License)](https://github.com/f4pga/prjxray/blob/master/LICENSE)
-![GitHub Actions](https://img.shields.io/github/workflow/status/f4pga/prjxray/Automerge/master?longCache=true&style=flat-square&label=GHA&logo=Github%20Actions&logoColor=fff)
+![GitHub Actions](https://img.shields.io/github/actions/workflow/status/f4pga/prjxray/Automerge.yml?branch=master&longCache=true&style=flat-square&label=GHA&logo=Github%20Actions&logoColor=fff)
 
 Documenting the Xilinx 7-series bit-stream format.
 


### PR DESCRIPTION
This PR updates the syntax of the broken shield/badge in the readme. See https://github.com/badges/shields/issues/8671 and https://github.com/antmicro/prjxray/blob/umarcor/shields/README.md.