### PR TITLE
Compile abseil-cpp with c++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ endif()
 add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/gflags EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/cctz EXCLUDE_FROM_ALL)
+
+# Set the CXX standard for our code, and abseil-cpp.
+set(CMAKE_CXX_STANDARD 14)
 add_subdirectory(third_party/abseil-cpp EXCLUDE_FROM_ALL)
 
 include(CheckCXXCompilerFlag)
@@ -36,8 +39,7 @@ target_include_directories(yaml-cpp PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party/yaml-cpp/include>
 	)
 
-# Set the CXX standard and compile time for our code only.
-set(CMAKE_CXX_STANDARD 14)
+
 add_compile_options(-Wall -Werror)
 
 add_subdirectory(lib)


### PR DESCRIPTION
The tools don't currently build on gcc11 (ubuntu22).

gcc11 defaults to c++17, causing dependencies (specifically abseil-c++) to be compiled with g++17; however, the current Makfile specifies c++14 for this codebase, which then won't link against abseil correctly.  

#1974 Proposed removing the c++14 flag on this codebase, but was closed without comment.
#1950 Proposes a fix of compiling abseil with c++14.  

This PR takes the latter approach, but either would probably be fine.  I'm just trying to get the ball rolling here...