### PR TITLE
Remove c++14 directive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,6 @@ target_include_directories(yaml-cpp PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party/yaml-cpp/include>
 	)
 
-# Set the CXX standard and compile time for our code only.
-set(CMAKE_CXX_STANDARD 14)
 add_compile_options(-Wall -Werror)
 
 add_subdirectory(lib)


### PR DESCRIPTION
This is an alternative to #2117.  Instead of compiling dependencies (abseil) with c++14, this PR removes this repo's c++14 directive.