### PR TITLE
Updated iterator class

### DIFF
--- a/lib/include/prjxray/big_endian_span.h
+++ b/lib/include/prjxray/big_endian_span.h
@@ -56,9 +56,15 @@ class BigEndianSpan {
 		absl::Span<ByteType> bytes_;
 	};
 
-	class iterator
-	    : public std::iterator<std::input_iterator_tag, value_type> {
+	class iterator {
 	       public:
+	       
+	        using iterator_category = std::input_iterator_tag;
+        	using value_type = BigEndianSpan::value_type;
+        	using difference_type = std::ptrdiff_t;
+        	using pointer = value_type*;
+        	using reference = value_type&;
+        	
 		value_type operator*() const { return value_type(bytes_); }
 
 		bool operator==(const iterator& other) const {

--- a/lib/include/prjxray/segbits_file_reader.h
+++ b/lib/include/prjxray/segbits_file_reader.h
@@ -34,9 +34,14 @@ class SegbitsFileReader {
 		absl::string_view bit_;
 	};
 
-	class iterator
-	    : public std::iterator<std::input_iterator_tag, value_type> {
-	       public:
+	class iterator {
+	     public:		
+        	using iterator_category = std::input_iterator_tag;
+        	using value_type = SegbitsFileReader::value_type;
+        	using difference_type = std::ptrdiff_t;
+        	using pointer = value_type*;
+        	using reference = value_type&;
+        	
 		iterator& operator++();
 
 		bool operator==(iterator other) const {

--- a/lib/include/prjxray/xilinx/bitstream_reader.h
+++ b/lib/include/prjxray/xilinx/bitstream_reader.h
@@ -33,9 +33,14 @@ class BitstreamReader {
 
 	// Implements an iterator over the words grouped in configuration
 	// packets.
-	class iterator
-	    : public std::iterator<std::input_iterator_tag, value_type> {
-	       public:
+	class iterator {
+	       public:	        
+	        using iterator_category = std::input_iterator_tag;
+        	using value_type = BitstreamReader::value_type;
+        	using difference_type = std::ptrdiff_t;
+        	using pointer = value_type*;
+        	using reference = value_type&;
+        	
 		iterator& operator++();
 
 		bool operator==(const iterator& other) const;

--- a/lib/include/prjxray/xilinx/bitstream_writer.h
+++ b/lib/include/prjxray/xilinx/bitstream_writer.h
@@ -51,9 +51,14 @@ class BitstreamWriter {
 	typedef absl::Span<const uint32_t>::iterator data_iterator_t;
 	using itr_value_type = uint32_t;
 
-	class packet_iterator
-	    : public std::iterator<std::input_iterator_tag, itr_value_type> {
-	       public:
+	class packet_iterator {
+	       public:	       
+	        using iterator_category = std::input_iterator_tag;
+        	using value_type = BitstreamWriter::itr_value_type;
+        	using difference_type = std::ptrdiff_t;
+        	using pointer = value_type*;
+        	using reference = value_type&;
+        	
 		packet_iterator& operator++();
 
 		bool operator==(const packet_iterator& other) const;
@@ -76,7 +81,7 @@ class BitstreamWriter {
 		    data_iterator_t itr_data);
 
 	       private:
-		friend iterator;
+		friend class iterator;
 		friend BitstreamWriter;
 
 		// Data iterators
@@ -89,9 +94,14 @@ class BitstreamWriter {
 		    packet_;
 	};
 
-	class iterator
-	    : public std::iterator<std::input_iterator_tag, itr_value_type> {
-	       public:
+	class iterator {
+	       public:	       
+	        using iterator_category = std::input_iterator_tag;
+        	using value_type = BitstreamWriter::itr_value_type;
+        	using difference_type = std::ptrdiff_t;
+        	using pointer = value_type*;
+        	using reference = value_type&;
+        	
 		iterator& operator++();
 
 		bool operator==(const iterator& other) const;


### PR DESCRIPTION
Updated the code which was using the std::iterator class, which has been marked as deprecated in the C++17 standard.