### PR TITLE
Add missing import for cstdint to tools/bits2rbt/header.h

### DIFF
--- a/tools/bits2rbt/header.h
+++ b/tools/bits2rbt/header.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class Header {
        public:


### PR DESCRIPTION
I got some issues compiling prjxray under gcc 13.1.1.
In order to mitigate this, I have added the missing import to tools/bits2rbt/header.h.

```
In file included from /home/dennis/tmp/prjxray/tools/bits2rbt/header.cc:1:
/home/dennis/tmp/prjxray/tools/bits2rbt/header.h:11:28: error: ‘uint32_t’ was not declared in this scope
   11 |                std::vector<uint32_t>& fpga_config_packets);
      |                            ^~~~~~~~
/home/dennis/tmp/prjxray/tools/bits2rbt/header.h:7:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    6 | #include <vector>
  +++ |+#include <cstdint>
    7 | 
/home/dennis/tmp/prjxray/tools/bits2rbt/header.h:11:36: error: template argument 1 is invalid
   11 |                std::vector<uint32_t>& fpga_config_packets);
      |                                    ^
/home/dennis/tmp/prjxray/tools/bits2rbt/header.h:11:36: error: template argument 2 is invalid
/home/dennis/tmp/prjxray/tools/bits2rbt/header.h:18:9: error: ‘uint32_t’ does not name a type
   18 |         uint32_t no_bits_;
      |         ^~~~~~~~
/home/dennis/tmp/prjxray/tools/bits2rbt/header.h:18:9: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
/home/dennis/tmp/prjxray/tools/bits2rbt/header.h:21:9: error: ‘uint32_t’ does not name a type
   21 |         uint32_t GetWord(absl::string_view& str_view);
      |         ^~~~~~~~
```