### PR TITLE
Fuzzer for STARTUPE2, ppips for CFG_CENTER_TOP/MID/BOT

### DIFF
--- a/fuzzers/038-cfg-startup/Makefile
+++ b/fuzzers/038-cfg-startup/Makefile
@@ -1,0 +1,21 @@
+# Copyright (C) 2017-2023  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+N := 4
+include ../fuzzer.mk
+
+database: build/segbits_cfg_center_mid.db
+
+build/segbits_cfg_center_mid.db: $(SPECIMENS_OK)
+	${XRAY_SEGMATCH} -c 3 -o build/segbits_cfg_center_mid.db $$(find -name segdata_cfg_center_mid.txt)
+	sed -i 's/CFG_CENTER/CFG_CENTER_MID/g' $@
+
+pushdb:
+	${XRAY_MERGEDB} cfg_center_mid build/segbits_cfg_center_mid.db
+
+.PHONY: database pushdb
+

--- a/fuzzers/038-cfg-startup/generate.py
+++ b/fuzzers/038-cfg-startup/generate.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+from prjxray.segmaker import Segmaker
+from prjxray import segmaker
+from prjxray import verilog
+import os
+import json
+import csv
+
+
+def bitfilter(frame, word):
+    if frame not in [26, 27]:
+        return False
+    return True
+
+def main():
+    print("Loading tags")
+    segmk = Segmaker("design.bits")
+
+    with open('params.json', 'r') as f:
+        design = json.load(f)
+
+        for d in design['tiles']:
+            print("design: " + str(d))
+            site = d['site']
+            tile = d['tile']
+
+            connection = d['CONNECTION']
+
+            if site.startswith('STARTUP'):
+                segmk.add_site_tag(site, 'USRCCLKO_CONNECTED', connection == "CLOCK")
+
+    segmk.compile(bitfilter=bitfilter)
+    segmk.write(allow_empty=True)
+
+if __name__ == "__main__":
+    main()

--- a/fuzzers/038-cfg-startup/generate.tcl
+++ b/fuzzers/038-cfg-startup/generate.tcl
@@ -1,0 +1,32 @@
+# Copyright (C) 2017-2020  The Project X-Ray Authors
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+source "$::env(XRAY_DIR)/utils/utils.tcl"
+
+proc run {} {
+    create_project -force -part $::env(XRAY_PART) design design
+    read_verilog top.v
+    synth_design -top top
+
+    set_property CFGBVS VCCO [current_design]
+    set_property CONFIG_VOLTAGE 3.3 [current_design]
+    set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
+    
+    create_clock -period 10.00 [get_ports clk]
+    set_property IS_ENABLED 0 [get_drc_checks {UCIO-1}]
+    set_property IS_ENABLED 0 [get_drc_checks {NSTD-1}]
+
+    write_checkpoint -force design_pre_place.dcp
+
+    place_design
+    route_design
+
+    write_checkpoint -force design.dcp
+    write_bitstream -force design.bit
+}
+
+run

--- a/fuzzers/038-cfg-startup/top.py
+++ b/fuzzers/038-cfg-startup/top.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017-2020  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+import json
+import io
+import os
+import random
+random.seed(int(os.getenv("SEED"), 16))
+from prjxray import util
+from prjxray import lut_maker
+from prjxray import verilog
+from prjxray.db import Database
+
+
+def gen_sites():
+    db = Database(util.get_db_root(), util.get_part())
+    grid = db.grid()
+    for tile_name in sorted(grid.tiles()):
+        if not 'CFG_CENTER_MID' in tile_name:
+            continue
+        print("// tile: " + str(tile_name))
+        loc = grid.loc_of_tilename(tile_name)
+        gridinfo = grid.gridinfo_at_loc(loc)
+
+        sites = {}
+        print("// " + str(gridinfo.sites.items()))
+        for site_name, site_type in gridinfo.sites.items():
+            if site_type == 'STARTUP':
+                print("// got site: " + str(site_name))
+                sites[site_type] = site_name
+
+        if sites:
+            yield tile_name, sites
+
+def run():
+    params = {
+        "tiles": [],
+    }
+
+    for tile, sites in gen_sites():
+        for site_type, site in sites.items():
+            p = {}
+            p['tile'] = tile
+            p['site'] = site
+
+            p['CONNECTION'] = random.choice(
+                (
+                    'HARD_ZERO',
+                    # hard zero or hard one does not make a difference
+                    # it only seems to matter if it is connected to a clock net or not
+                    #'HARD_ONE',
+                    'CLOCK',
+                ))
+
+            params['tiles'].append(p)
+
+    print(
+    '''
+module top (input  wire clk);
+    (* KEEP, DONT_TOUCH *)
+    STARTUPE2 STARTUPE2 (
+        .CLK(1'b0),
+        .GSR(1'b0),
+        .GTS(1'b0),
+        .KEYCLEARB(1'b1),
+        .PACK(1'b0),
+        .PREQ(),
+  
+        // Drive clock.''')
+
+    connection = p['CONNECTION']
+
+    if connection == "HARD_ZERO":
+        print("        .USRCCLKO (1'b0),")
+    elif connection == "HARD_ONE":
+        print("        .USRCCLKO (1'b1),")
+    else:    
+        print("        .USRCCLKO (clk),")
+
+    print(
+    '''
+        .USRCCLKTS(1'b0),  
+        .USRDONEO (1'b0),
+        .USRDONETS(1'b1),
+        .CFGCLK(),
+        .CFGMCLK(),
+        .EOS()
+    );
+
+endmodule
+''')
+
+    with open('params.json', 'w') as f:
+        json.dump(params, f, indent=2)
+
+if __name__ == '__main__':
+    run()

--- a/fuzzers/071-ppips/generate.tcl
+++ b/fuzzers/071-ppips/generate.tcl
@@ -90,6 +90,23 @@ proc write_bram_ppips_db {filename tile} {
     close $fp
 }
 
+proc write_cfg_ppips_db {filename tile} {
+    set fp [open $filename "w"]
+    set tile [get_tiles $tile]
+    set tile_type [get_property TILE_TYPE $tile]
+
+    foreach pip [get_pips -of_objects $tile] {
+        set dst_wire [get_wires -downhill -of_objects $pip]
+        if {[get_pips -uphill -of_objects [get_nodes -of_objects $dst_wire]] == $pip} {
+            set src_wire [get_wires -uphill -of_objects $pip]
+            puts $fp "${tile_type}.[regsub {.*/} $dst_wire ""].[regsub {.*/} $src_wire ""] always"
+        }
+    }
+
+    close $fp
+}
+
+
 proc write_dsp_ppips_db {filename tile} {
     set fp [open $filename "w"]
     set tile [get_tiles $tile]
@@ -335,6 +352,14 @@ foreach tile_type {BRAM_L BRAM_R} {
     if {[llength $tiles] != 0} {
         set tile [lindex $tiles 0]
         write_bram_ppips_db "ppips_[string tolower $tile_type].db" $tile
+    }
+}
+
+foreach tile_type {CFG_CENTER_MID} {
+    set tiles [get_tiles -filter "TILE_TYPE == $tile_type"]
+    if {[llength $tiles] != 0} {
+        set tile [lindex $tiles 0]
+        write_cfg_ppips_db "ppips_[string tolower $tile_type].db" $tile
     }
 }
 

--- a/fuzzers/071-ppips/generate.tcl
+++ b/fuzzers/071-ppips/generate.tcl
@@ -355,7 +355,7 @@ foreach tile_type {BRAM_L BRAM_R} {
     }
 }
 
-foreach tile_type {CFG_CENTER_MID} {
+foreach tile_type {CFG_CENTER_TOP CFG_CENTER_MID CFG_CENTER_BOT} {
     set tiles [get_tiles -filter "TILE_TYPE == $tile_type"]
     if {[llength $tiles] != 0} {
         set tile [lindex $tiles 0]

--- a/fuzzers/Makefile
+++ b/fuzzers/Makefile
@@ -145,6 +145,7 @@ ifeq ($(HAS_HIGH_PERFORMANCE_BANKS),1)
 $(eval $(call fuzzer,037-iob18-pips,005-tilegrid 035b-iob-iserdes,all))
 endif
 $(eval $(call fuzzer,038-cfg,005-tilegrid,all))
+$(eval $(call fuzzer,038-cfg-startup,005-tilegrid,all))
 $(eval $(call fuzzer,039-hclk-config,005-tilegrid,all))
 $(eval $(call fuzzer,040-clk-hrow-config,005-tilegrid,all))
 $(eval $(call fuzzer,041-clk-hrow-pips,005-tilegrid,all))


### PR DESCRIPTION
This contains a fuzzer for bits that only show up, when USRCCLKO is connected to
a non-constant net.
Also it turned out that the switchboxes on the CFG_CENTER tiles are all pseudo.
I have been able to get a working BSCANE2 with those,
and also a working STARTUPE2 test.
Since the other primitives are not that much different qualitatively,
I reckon most CFG_CENTER primitives should work with this.