### PR TITLE
036-iob-ologic: Also fuzz DATA_WIDTH 10 and 14

### DIFF
--- a/fuzzers/036-iob-ologic/generate.py
+++ b/fuzzers/036-iob-ologic/generate.py
@@ -42,7 +42,7 @@ def no_oserdes(segmk, site):
             widths = [2, 3, 4, 5, 6, 7, 8]
         else:
             assert mode == 'DDR'
-            widths = [4, 6, 8]
+            widths = [4, 6, 8, 10, 14]
 
         for opt in widths:
             segmk.add_site_tag(

--- a/fuzzers/036-iob-ologic/generate.tcl
+++ b/fuzzers/036-iob-ologic/generate.tcl
@@ -94,6 +94,8 @@ proc run {} {
     set_property BITSTREAM.GENERAL.PERFRAMECRC YES [current_design]
     set_property IS_ENABLED 0 [get_drc_checks {REQP-79}]
     set_property IS_ENABLED 0 [get_drc_checks {REQP-144}]
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-150}]
+    set_property IS_ENABLED 0 [get_drc_checks {REQP-152}]
 
     write_checkpoint -force design_pre_place.dcp
 

--- a/fuzzers/036-iob-ologic/top.py
+++ b/fuzzers/036-iob-ologic/top.py
@@ -64,7 +64,7 @@ def use_oserdese2(p, luts, connects):
     if verilog.unquote(p['DATA_RATE_OQ']) == 'SDR':
         data_widths = [2, 3, 4, 5, 6, 7, 8]
     else:
-        data_widths = [4, 6, 8]
+        data_widths = [4, 6, 8, 10, 14]
 
     p['DATA_WIDTH'] = random.choice(data_widths)
 


### PR DESCRIPTION
This enables master/slave support, because that is what those datawidths are for.